### PR TITLE
Avoid CSRF token generation races, path removal and age updating

### DIFF
--- a/src/KaraLib/src/kara/internal/ResourceDescriptor.kt
+++ b/src/KaraLib/src/kara/internal/ResourceDescriptor.kt
@@ -99,10 +99,11 @@ class ResourceDescriptor(val httpMethod: HttpMethod, val route: String, val reso
         val actionContext = ActionContext(context, request, response, params)
 
         actionContext.withContext {
-            val sessionToken = actionContext.sessionToken()
             val actionResult = when {
-                !allowCrossOrigin && params[ActionContext.SESSION_TOKEN_PARAMETER] != sessionToken -> ErrorResult(403, "This request is only valid within same origin")
-                else -> routeInstance.handle(actionContext)
+                !allowCrossOrigin && params[ActionContext.SESSION_TOKEN_PARAMETER] != actionContext.sessionToken() ->
+                    ErrorResult(403, "This request is only valid within same origin")
+                else ->
+                    routeInstance.handle(actionContext)
             }
 
             actionResult.writeResponse(actionContext)


### PR DESCRIPTION
- CSRF cookie is alive until browser session is active, i.e. while site tab is open, cookie is present. On tab restore a form would be regenerated (including its token), the cookie would be set again. 
- Cookie is added to response only if it is absent in request.