### PR TITLE
Use Java to bypass bad Kotlin signatures (workaround for KT-7807)

### DIFF
--- a/src/KaraLib/src/kara/Resource.kt
+++ b/src/KaraLib/src/kara/Resource.kt
@@ -6,8 +6,6 @@ import javax.servlet.http.HttpServletRequest
 import java.lang.reflect.Modifier
 import kara.internal.*
 import kotlinx.reflection.*
-import org.jetbrains.kotlin.load.java.structure.reflect.desc
-import org.jetbrains.kotlin.load.java.structure.reflect.findAnnotation
 import java.util.HashSet
 import java.util.LinkedHashSet
 import kotlin.html.*

--- a/src/KaraLib/src/kara/internal/RoutesBuilder.kt
+++ b/src/KaraLib/src/kara/internal/RoutesBuilder.kt
@@ -3,7 +3,6 @@ package kara.internal
 import kotlinx.reflection.*
 import java.util.ArrayList
 import kara.*
-import org.jetbrains.kotlin.load.java.reflect.tryLoadClass
 import java.lang.instrument.Instrumentation
 import kotlin.reflect.jvm.kotlin
 

--- a/src/ReflectionUtil/src/kotlinx/reflection/ReflectionUtil.java
+++ b/src/ReflectionUtil/src/kotlinx/reflection/ReflectionUtil.java
@@ -1,0 +1,10 @@
+package kotlinx.reflection;
+
+import kotlin.reflect.jvm.internal.KClassImpl;
+import kotlin.reflect.jvm.internal.impl.descriptors.ClassDescriptor;
+
+class ReflectionUtil {
+    static ClassDescriptor getClassDescriptor(KClassImpl<?> klass) {
+        return klass.getDescriptor();
+    }
+}


### PR DESCRIPTION
Workaround for Kotlin bug "Some declarations left unrenamed in Kotlin annotations in kotlin-reflect.jar"
https://youtrack.jetbrains.com/issue/KT-7807